### PR TITLE
[transfer-engine] Ensure notifications are shown for non-file transfers

### DIFF
--- a/src/transferengine_p.h
+++ b/src/transferengine_p.h
@@ -106,7 +106,7 @@ public:
     void recoveryCheck();
     void sendNotification(TransferEngineData::TransferType type,
                           TransferEngineData::TransferStatus status,
-                          const QUrl &filePath);
+                          const QString &fileName);
     int uploadMediaItem(MediaItem *mediaItem,
                         MediaTransferInterface *muif,
                         const QVariantMap &userData);
@@ -128,7 +128,7 @@ public:
     QStringList pluginList() const;
     QList <TransferMethodInfo> enabledPlugins() const;
     MediaTransferInterface *loadPlugin(const QString &pluginId) const;
-
+    QString mediaFileOrResourceName(MediaItem *mediaItem) const;
 
     QMap <MediaTransferInterface*, int> m_plugins;
     QMap <int, TransferEngineData::TransferType> m_keyTypeCache;


### PR DESCRIPTION
Allow MediaItem::ResourceName to be passed to sendNotification() when
MediaItem::Url is empty, as it will be if an uploader is sending a
non-file resource such as a vCard.
