### PR TITLE
[nemo-transfer-engine] Use invoker to launch transfer engine

### DIFF
--- a/dbus/org.nemo.transferengine.service
+++ b/dbus/org.nemo.transferengine.service
@@ -1,4 +1,4 @@
 [D-BUS Service]
 Interface=/org/nemo/transferengine
 Name=org.nemo.transferengine
-Exec=/usr/bin/nemo-transfer-engine
+Exec=/usr/bin/invoker --type=generic /usr/bin/nemo-transfer-engine


### PR DESCRIPTION
Previously, the transfer engine wasn't invoked, but instead launched
directly.  This means that it would not have privileges.
