### PR TITLE
[nemo-transfer-engine] Now title or description is actually stored to the database.

### DIFF
--- a/src/dbmanager.cpp
+++ b/src/dbmanager.cpp
@@ -766,7 +766,7 @@ MediaItem * DbManager::mediaItem(int key) const
     //       this point if there isn't anything...
     if (query.next()) {
         item->setValue(MediaItem::Title, query.value(rec.indexOf("title")));
-        item->setValue(MediaItem::Title, query.value(rec.indexOf("description")));
+        item->setValue(MediaItem::Description, query.value(rec.indexOf("description")));
     }
 
     query.finish();


### PR DESCRIPTION
Previously none of the descriptions or titles weren't saved to the database. Meaning that if sharing was restarted after failure, it didn't add description and only image was shared.
