### PR TITLE
[transfer-engine] Delay transfer engine exit

### DIFF
--- a/src/transferengine.cpp
+++ b/src/transferengine.cpp
@@ -178,6 +178,16 @@ void TransferEnginePrivate::exitSafely()
 {
     if (!m_activityMonitor->activeTransfers()) {
         qDebug() << Q_FUNC_INFO;
+        QTimer::singleShot(2000, this, SLOT(delayedExitSafely()));
+    }
+}
+
+void TransferEnginePrivate::delayedExitSafely()
+{
+    if (m_activityMonitor->activeTransfers()) {
+        qDebug() << "Keeping transfer engine alive, transfers still ongoing";
+    } else {
+        qDebug() << "Stopping transfer engine";
         qApp->exit();
     }
 }

--- a/src/transferengine_p.h
+++ b/src/transferengine_p.h
@@ -118,6 +118,7 @@ public:
 
 public Q_SLOTS:
     void exitSafely();
+    void delayedExitSafely();
     void enabledPluginsCheck();
     void cleanupExpiredTransfers(const QList<int> &expiredIds);
     void pluginDirChanged();


### PR DESCRIPTION
When transferring multiple files via Bluetooth, we quickly receive
one transfer request after another, so this causes a timing issue
where the engine may quit immediately after the first request and
is in the process of closing down when the next request is received,
and thus cannot be started again for the next request.
