### PR TITLE
Added share plugin example

### DIFF
--- a/example/ExampleShareUI.qml
+++ b/example/ExampleShareUI.qml
@@ -1,0 +1,84 @@
+/******************************************************************************
+Copyright (c) <2014>, Jolla Ltd.
+Contact: Marko Mattila <marko.mattila@jolla.com>
+
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+    Redistributions of source code must retain the above copyright notice, this
+    list of conditions and the following disclaimer. Redistributions in binary
+    form must reproduce the above copyright notice, this list of conditions and
+    the following disclaimer in the documentation and/or other materials
+    provided with the distribution. Neither the name of the Jolla Ltd. nor
+    the names of its contributors may be used to endorse or promote products
+    derived from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+******************************************************************************/
+
+import QtQuick 2.0
+import Sailfish.Silica 1.0
+import org.nemomobile.thumbnailer 1.0
+import Sailfish.TransferEngine 1.0
+
+ShareDialog {
+    id: root
+
+    property int viewWidth: root.isPortrait ? Screen.width : Screen.width / 2
+
+    onAccepted: {
+        shareItem.start()
+    }
+
+    Thumbnail {
+        id: thumbnail
+        width: viewWidth
+        height: parent.height / 2
+        source: root.source
+        sourceSize.width: Screen.width
+        sourceSize.height: Screen.height / 2
+    }
+
+    Item {
+        anchors {
+            top: root.isPortrait ? thumbnail.bottom : parent.top
+            left: root.isPortrait ? parent.left: thumbnail.right
+            right: parent.right
+            bottom: parent.bottom
+        }
+
+        Label {
+            anchors.centerIn:parent
+            width: viewWidth
+            text: "Example Test Share UI"
+            horizontalAlignment: Text.AlignHCenter
+        }
+    }
+
+    SailfishShare {
+        id: shareItem
+        source: root.source
+        metadataStripped: true
+        serviceId: root.methodId
+        userData: {"description": "Random Text which can be what ever",
+                   "accountId": root.accountId,
+                   "scalePercent": root.scalePercent}
+    }
+
+    DialogHeader {
+        // TODO: Localization not supported for 3rd party plugins yet
+        acceptText: "Example Share"
+    }
+}
+

--- a/example/example.pro
+++ b/example/example.pro
@@ -1,0 +1,64 @@
+TEMPLATE = lib
+TARGET = $$qtLibraryTarget(exampleshareplugin)
+CONFIG += plugin
+DEPENDPATH += .
+
+CONFIG += link_pkgconfig
+PKGCONFIG += nemotransferengine-qt5
+
+# Input
+HEADERS += \
+    exampleplugininfo.h \
+    exampleuploader.h \
+    exampleshareplugin.h
+
+SOURCES += \
+    exampleplugininfo.cpp \
+    exampleuploader.cpp \
+    exampleshareplugin.cpp
+
+OTHER_FILES += \
+    ExampleShareUI.qml
+
+
+shareui.files = *.qml
+shareui.path = /usr/share/nemo-transferengine/plugins
+
+target.path = /usr/lib/nemo-transferengine/plugins
+INSTALLS += target shareui
+
+
+TS_FILE = $$OUT_PWD/example_share_plugin.ts
+EE_QM = $$OUT_PWD/example_share_plugin_eng_en.qm
+
+ts.commands += lupdate . -ts $$TS_FILE
+ts.CONFIG += no_check_exist no_link
+ts.output = $$TS_FILE
+ts.input = ..
+
+ts_install.files = $$TS_FILE
+ts_install.path = /usr/share/translations/source
+ts_install.CONFIG += no_check_exist
+
+# should add -markuntranslated "-" when proper translations are in place (or for testing)
+engineering_english.commands += lrelease -idbased $$TS_FILE -qm $$EE_QM
+engineering_english.CONFIG += no_check_exist no_link
+engineering_english.depends = ts
+engineering_english.input = $$TS_FILE
+engineering_english.output = $$EE_QM
+
+engineering_english_install.path = /usr/share/translations
+engineering_english_install.files = $$EE_QM
+engineering_english_install.CONFIG += no_check_exist
+
+QMAKE_EXTRA_TARGETS += ts engineering_english
+
+PRE_TARGETDEPS += ts engineering_english
+
+INSTALLS += ts_install engineering_english_install
+
+
+
+OTHER_FILES += \
+    rpm/*
+    translations/*

--- a/example/exampleplugininfo.cpp
+++ b/example/exampleplugininfo.cpp
@@ -1,0 +1,85 @@
+/******************************************************************************
+Copyright (c) <2014>, Jolla Ltd.
+Contact: Marko Mattila <marko.mattila@jolla.com>
+
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+    Redistributions of source code must retain the above copyright notice, this
+    list of conditions and the following disclaimer. Redistributions in binary
+    form must reproduce the above copyright notice, this list of conditions and
+    the following disclaimer in the documentation and/or other materials
+    provided with the distribution. Neither the name of the Jolla Ltd. nor
+    the names of its contributors may be used to endorse or promote products
+    derived from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+******************************************************************************/
+
+#include "exampleplugininfo.h"
+
+ExamplePluginInfo::ExamplePluginInfo()
+    : m_ready(false)
+{
+
+}
+
+ExamplePluginInfo::~ExamplePluginInfo()
+{
+
+}
+
+QList<TransferMethodInfo> ExamplePluginInfo::info() const
+{
+    return m_infoList;
+}
+
+void ExamplePluginInfo::query()
+{
+    TransferMethodInfo info;
+    QStringList capabilities;
+
+    // Capabilites ie. what mimetypes this plugin supports
+    capabilities << QLatin1String("image/*")
+                 << QLatin1String("text/vcard");
+
+    // TODO: Translations for 3rd party plugins is not yet supported by Sailfish OS.
+    //       Adding support there later, but for now just use what ever non-translated
+    //       string here. This string will be visible in the share method list.
+    info.displayName     = "Example Display Name";
+
+    // Method ID is a unique identifier for this plugin. It is used to identify which share plugin should be
+    // used for starting the sharing.
+    info.methodId        = QLatin1String("Example-Share-Method-ID");
+
+    // Path to the Sharing UI which this plugin provides.
+    info.shareUIPath     = QLatin1String("/usr/share/nemo-transferengine/plugins/ExampleShareUI.qml");
+
+    // Pass information about capabilities. This info is used for filtering share plugins
+    // which don't support defined types. For example, this plugin won't appear in the
+    // share method list, if someone tries to share content which isn't image or vcard type,
+    info.capabilitities  = capabilities;
+
+    m_infoList << info;
+
+    // Let the world know that this plugin is ready
+    m_ready = true;
+    emit infoReady();
+}
+
+
+bool ExamplePluginInfo::ready() const
+{
+    return m_ready;
+}

--- a/example/exampleplugininfo.h
+++ b/example/exampleplugininfo.h
@@ -1,0 +1,49 @@
+/******************************************************************************
+Copyright (c) <2014>, Jolla Ltd.
+Contact: Marko Mattila <marko.mattila@jolla.com>
+
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+    Redistributions of source code must retain the above copyright notice, this
+    list of conditions and the following disclaimer. Redistributions in binary
+    form must reproduce the above copyright notice, this list of conditions and
+    the following disclaimer in the documentation and/or other materials
+    provided with the distribution. Neither the name of the Jolla Ltd. nor
+    the names of its contributors may be used to endorse or promote products
+    derived from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+******************************************************************************/
+#ifndef EXAMPLEPLUGININFO_H
+#define EXAMPLEPLUGININFO_H
+
+#include "transferplugininfo.h"
+
+class ExamplePluginInfo : public TransferPluginInfo
+{
+    Q_OBJECT
+public:
+    ExamplePluginInfo();
+    ~ExamplePluginInfo();
+
+    QList<TransferMethodInfo> info() const;
+    void query();
+    bool ready() const;
+private:
+    QList<TransferMethodInfo> m_infoList;
+    bool m_ready;
+};
+
+#endif // EXAMPLEPLUGININFO_H

--- a/example/exampleshareplugin.cpp
+++ b/example/exampleshareplugin.cpp
@@ -1,0 +1,62 @@
+/******************************************************************************
+Copyright (c) <2014>, Jolla Ltd.
+Contact: Marko Mattila <marko.mattila@jolla.com>
+
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+    Redistributions of source code must retain the above copyright notice, this
+    list of conditions and the following disclaimer. Redistributions in binary
+    form must reproduce the above copyright notice, this list of conditions and
+    the following disclaimer in the documentation and/or other materials
+    provided with the distribution. Neither the name of the Jolla Ltd. nor
+    the names of its contributors may be used to endorse or promote products
+    derived from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+******************************************************************************/
+
+#include "exampleshareplugin.h"
+#include "exampleuploader.h"
+#include "exampleplugininfo.h"
+#include <QtPlugin>
+
+ExampleSharePlugin::ExampleSharePlugin()
+{
+}
+
+ExampleSharePlugin::~ExampleSharePlugin()
+{
+}
+
+MediaTransferInterface * ExampleSharePlugin::transferObject()
+{
+    return new ExampleUploader;
+}
+
+TransferPluginInfo *ExampleSharePlugin::infoObject()
+{
+    return new ExamplePluginInfo;
+}
+
+QString ExampleSharePlugin::pluginId() const
+{
+    return "Example-Share-Method-ID";
+}
+
+bool ExampleSharePlugin::enabled() const
+{
+    return true;
+}
+

--- a/example/exampleshareplugin.h
+++ b/example/exampleshareplugin.h
@@ -1,0 +1,51 @@
+/******************************************************************************
+Copyright (c) <2014>, Jolla Ltd.
+Contact: Marko Mattila <marko.mattila@jolla.com>
+
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+    Redistributions of source code must retain the above copyright notice, this
+    list of conditions and the following disclaimer. Redistributions in binary
+    form must reproduce the above copyright notice, this list of conditions and
+    the following disclaimer in the documentation and/or other materials
+    provided with the distribution. Neither the name of the Jolla Ltd. nor
+    the names of its contributors may be used to endorse or promote products
+    derived from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+******************************************************************************/
+
+#ifndef EXAMPLESHAREPLUGIN_H
+#define EXAMPLESHAREPLUGIN_H
+#include "transferplugininterface.h"
+#include <QObject>
+
+class Q_DECL_EXPORT ExampleSharePlugin : public QObject, public TransferPluginInterface
+{
+    Q_OBJECT
+    Q_PLUGIN_METADATA(IID "com.myapp.transfer.plugin.example")
+    Q_INTERFACES(TransferPluginInterface)
+public:
+    ExampleSharePlugin();
+    ~ExampleSharePlugin();
+
+    MediaTransferInterface * transferObject();
+    TransferPluginInfo *infoObject();
+    QString pluginId() const;
+    bool enabled() const ;
+
+};
+
+#endif // EXAMPLESHAREPLUGIN_H

--- a/example/exampleuploader.cpp
+++ b/example/exampleuploader.cpp
@@ -1,0 +1,82 @@
+/******************************************************************************
+Copyright (c) <2014>, Jolla Ltd.
+Contact: Marko Mattila <marko.mattila@jolla.com>
+
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+    Redistributions of source code must retain the above copyright notice, this
+    list of conditions and the following disclaimer. Redistributions in binary
+    form must reproduce the above copyright notice, this list of conditions and
+    the following disclaimer in the documentation and/or other materials
+    provided with the distribution. Neither the name of the Jolla Ltd. nor
+    the names of its contributors may be used to endorse or promote products
+    derived from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+******************************************************************************/
+
+#include "exampleuploader.h"
+#include "mediaitem.h"
+
+ExampleUploader::ExampleUploader(QObject *parent):
+    MediaTransferInterface(parent)
+{
+
+}
+
+ExampleUploader::~ExampleUploader()
+{
+}
+
+QString ExampleUploader::displayName() const
+{
+    return tr("Example");
+}
+
+QUrl ExampleUploader::serviceIcon() const
+{
+    // Url to the icon which should be shown in the transfer UI
+    return QUrl("image://theme/icon-s-message");
+}
+
+bool ExampleUploader::cancelEnabled() const
+{
+    // Return true if cancelling ongoing upload is supported
+    // Return false if cancelling ongoing upload is not supported
+    return false;
+}
+
+bool ExampleUploader::restartEnabled() const
+{
+    // Return true, if restart is  supported.
+    // Return false, if restart is not supported
+    return false;
+}
+
+
+void ExampleUploader::start()
+{
+    // This is called by the sharing framework to start sharing
+
+    // TODO: Add your code here to start uploading
+}
+
+void ExampleUploader::cancel()
+{
+    // This is called by the sharing framework to cancel on going transfer
+
+    // TODO: Add your code here to cancel ongoing upload
+}
+

--- a/example/exampleuploader.h
+++ b/example/exampleuploader.h
@@ -1,0 +1,51 @@
+/******************************************************************************
+Copyright (c) <2014>, Jolla Ltd.
+Contact: Marko Mattila <marko.mattila@jolla.com>
+
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+    Redistributions of source code must retain the above copyright notice, this
+    list of conditions and the following disclaimer. Redistributions in binary
+    form must reproduce the above copyright notice, this list of conditions and
+    the following disclaimer in the documentation and/or other materials
+    provided with the distribution. Neither the name of the Jolla Ltd. nor
+    the names of its contributors may be used to endorse or promote products
+    derived from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+******************************************************************************/
+
+#ifndef EXAMPLEUPLOADER_H
+#define EXAMPLEUPLOADER_H
+#include "mediatransferinterface.h"
+
+class ExampleUploader : public MediaTransferInterface
+{
+    Q_OBJECT
+public:
+    ExampleUploader(QObject *parent = 0);
+    ~ExampleUploader();
+
+    QString displayName() const;
+    QUrl serviceIcon() const;
+    bool cancelEnabled() const;
+    bool restartEnabled() const;
+
+public Q_SLOTS:
+    void start();
+    void cancel();
+};
+
+#endif // EXAMPLEUPLOADER_H

--- a/example/rpm/example.spec
+++ b/example/rpm/example.spec
@@ -1,0 +1,51 @@
+Name: example-share-plugin
+Version: 0.0.1
+Release: 0
+Summary: Share plugins for nemo transfer engine
+Group: System/Libraries
+License: LICENCE
+URL: https://github.com/nemomobile/transfer-engine
+Source0: %{name}-%{version}.tar.gz
+BuildRequires: pkgconfig(Qt5Core)
+BuildRequires: pkgconfig(Qt5Qml)
+BuildRequires: pkgconfig(nemotransferengine-qt5)
+BuildRequires: qt5-qttools
+BuildRequires: qt5-qttools-linguist
+
+Requires:  nemo-transferengine-qt5
+Requires:  declarative-transferengine-qt5 >= 0.0.44
+
+%description
+%{summary}.
+
+%files
+%defattr(-,root,root,-)
+%{_libdir}/nemo-transferengine/plugins/*shareplugin.so
+%{_datadir}/nemo-transferengine/plugins/*.qml
+%{_datadir}/translations/example_share_plugin_eng_en.qm
+
+%package ts-devel
+Summary:   Translation source for Transfer Engine share plugins
+License:   TBD
+Group:     System/Libraries
+
+%description ts-devel
+Translation source for Transfer Engine share plugins
+
+%files ts-devel
+%defattr(-,root,root,-)
+%{_datadir}/translations/source/example_share_plugin.ts
+
+%prep
+%setup -q -n %{name}-%{version}
+
+%build
+
+%qmake5
+
+make %{?jobs:-j%jobs}
+
+%install
+rm -rf %{buildroot}
+%qmake5_install
+


### PR DESCRIPTION
This is not built with the default RPM package, but can be used as a skeleton to build real life share plugins. QML part may still change, but the C++ code is quite stabilized already.
