### PR TITLE
[transfer-engine] Fix QSqlDatabase leak.

### DIFF
--- a/declarative/declarativetransfermodel.cpp
+++ b/declarative/declarativetransfermodel.cpp
@@ -49,19 +49,19 @@ template <> bool compareIdentity<TransferDBRecord>(
 class QSqlDatabaseWrapper
 {
 public:
-  QSqlDatabaseWrapper(const QSqlDatabase& db) : m_db(db) {}
-  ~QSqlDatabaseWrapper() {
-    QString name = m_db.connectionName();
-    m_db = QSqlDatabase(); // Drop our last reference.
-    if (!name.isEmpty()) {
-      QSqlDatabase::removeDatabase(name);
+    QSqlDatabaseWrapper(const QSqlDatabase& db) : m_db(db) {}
+    ~QSqlDatabaseWrapper() {
+        QString name = m_db.connectionName();
+	m_db = QSqlDatabase(); // Drop our last reference.
+	if (!name.isEmpty()) {
+	    QSqlDatabase::removeDatabase(name);
+	}
     }
-  }
 
-  QSqlDatabase& database() { return m_db; }
+    QSqlDatabase& database() { return m_db; }
 
 private:
-  QSqlDatabase m_db;
+    QSqlDatabase m_db;
 };
 
 TransferModel::TransferModel(QObject *parent)


### PR DESCRIPTION
We need to remove the database from the list of connections in order to really close
the database and cleanup any temporary files left.
