### PR TITLE
Make sure transfer engine stop if booster goes away.

### DIFF
--- a/transferengine.service
+++ b/transferengine.service
@@ -1,10 +1,10 @@
 [Unit]
 Description=Transfer engine
 After=dbus.socket booster-qt5.service
-Requires=dbus.socket
+Requires=dbus.socket booster-qt5.service
 
 [Service]
-ExecStart=/usr/bin/invoker --type=qt5 --global-syms /usr/bin/nemo-transfer-engine
 Type=dbus
+ExecStart=/usr/bin/invoker --type=qt5 --global-syms /usr/bin/nemo-transfer-engine
 BusName=org.nemo.transferengine
 


### PR DESCRIPTION
[systemd] Require booster-qt5.

Signed-off-by: Marko Saukko marko.saukko@jolla.com
