### PR TITLE
[transfer-engine] Initialize angle and mirrored variables in metadata…

### DIFF
--- a/lib/imageoperation.cpp
+++ b/lib/imageoperation.cpp
@@ -321,17 +321,16 @@ QString ImageOperation::scaleImageToSize(const QString &sourceFile, quint64 targ
 
 void ImageOperation::imageOrientation(const QString &sourceFile, int *angle, bool *mirror)
 {
+    *angle = 0;
+    *mirror = false;
+
     if(!QuillMetadata::canRead(sourceFile)) {
         qWarning() << Q_FUNC_INFO << "Can't read metadata";
-        *angle = 0;
-        *mirror = false;
         return;
     }
     QuillMetadata md(sourceFile);
     if (!md.hasExif()) {
         qWarning() << "Metadata invalid";
-        *angle = 0;
-        *mirror = false;
         return;
     }
 


### PR DESCRIPTION
… handling. Fixes MER#1278

If source image has exif orientation 0 then imageOrientation method leaves angle and mirrored variables uninitialized, causing the resulting image to be mirrored and rotated randomly.